### PR TITLE
fixing title setting logic

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ function html5_embed_renderer(tokens, idx, options, env, renderer, defaultRender
     isLink = true;
     title = tokens[idx+1].content;
   } else {
-    title = token.attrs[token.attrIndex('alt')][1];
+    title = token.content;
   }
 //  console.log('aindex of idx' + idx);
 //  console.log(aIndex);
@@ -119,4 +119,3 @@ module.exports = function html5_embed_plugin(md, options) {
     };
   }
 };
-


### PR DESCRIPTION
Please inspect this change and merge it. Without this change, ![title](link) would not be rendered correctly and title would be set to "untitled video/audio".