### PR TITLE
Remove lodash dependency

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,6 @@
 'use strict';
 
 var Mimoza = require('mimoza');
-var assign = require("lodash.assign");
 
 function clearTokens(tokens, idx) {
   for(var i = idx; i < tokens.length; i++) {
@@ -148,7 +147,7 @@ module.exports = function html5_embed_plugin(md, options) {
     autoAppend: false,
     embedPlaceDirectiveRegexp: /^\[\[html5media\]\]/im
   };
-  var options = assign({}, defaults, options.html5embed);
+  var options = md.utils.assign({}, defaults, options.html5embed);
 
   if(!options.inline) {
     md.block.ruler.before("paragraph", "html5embed", function(state, startLine, endLine, silent) {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
   },
   "dependencies": {
     "markdown-it": "^8.4.0",
-    "mimoza": "~1.0.0",
-    "lodash.assign": "~4.2.0"
+    "mimoza": "~1.0.0"
   },
   "devDependencies": {
     "handlebars": "~4.0.10",


### PR DESCRIPTION
`md` exposes an assign function, which can be used for option merging. So the dependency on lodash.assign is not really necessary and can be removed. Saves a few bytes :)