### PR TITLE
Translation suport; use tag content for fallback text

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ an object like this as its only argument, and return a string:
 }
 ````
 
-The keys you need to support are defined in `/lib.index.js`. You can access the
+The keys you need to support are defined in `lib/index.js`. You can access the
 default messages, or the messages you passed via `options.messages`, through
 the `this` keyword within your translation function.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ var md = require('markdown-it')()
 
 md.render('![](http://example.com/file.webm)'); // => '<p><video width="320" height="240" class="audioplayer" controls>
                                                 // <source type="video/webm" src=https://example.com/file.webm></source>
-                                                // untitled video
+                                                // Fallback text (see below)
                                                 // </video></p>'
 ```
 
@@ -58,7 +58,10 @@ Rendered:
 ```html
 <p><video controls preload="metadata">
 <source type="video/webm" src="https://example.com/file.webm"></source>
-test link
+Your browser does not support playing HTML5 video. You can
+<a href="https://example.com/file.webm" download>download a copy of the video
+file</a> instead.
+Here is a description of the content: test link
 </video></p>
 ```
 
@@ -80,7 +83,9 @@ Rendered:
 ```html
 <p><video width="320" height="240" class="audioplayer" controls>
 <source type="video/webm" src="https://example.com/file.webm"></source>
-untitled video
+Your browser does not support playing HTML5 video. You can
+<a href="https://example.com/file.webm" download>download a copy of the video
+file</a> instead.
 </video></p>
 ```
 
@@ -111,7 +116,10 @@ Rendered:
 <p><a href="https://example.com/file.webm">test link</a></p>
 <video controls preload="metadata">
 <source type="video/webm" src="https://example.com/file.webm"></source>
-test link
+Your browser does not support playing HTML5 video. You can
+<a href="https://example.com/file.webm" download>download a copy of the video
+file</a> instead.
+Here is a description of the content: test link
 </video>
 ```
 
@@ -123,7 +131,7 @@ inline: false,
 autoAppend: true
 ```
 
-In this mode media files are embedded at the end of the rendered text without any specific directives. 
+In this mode media files are embedded at the end of the rendered text without any specific directives.
 
 This mode always uses link syntax.
 
@@ -138,7 +146,10 @@ Rendered:
 <p><a href="https://example.com/file.webm">test link</a></p>
 <video controls preload="metadata">
 <source type="video/webm" src="https://example.com/file.webm"></source>
-test link
+Your browser does not support playing HTML5 video. You can
+<a href="https://example.com/file.webm" download>download a copy of the video
+file</a> instead.
+Here is a description of the content: test link
 </video>
 ```
 
@@ -151,6 +162,12 @@ templateName: "media-embed_tpl"
 
 If you want to render media embed using Handlebars template, you can set `templateName` option and the plugin will try to find
 the template using global `HandlebarsTemplates` array and render using this template.    
+
+You can access the descriptive content (e.g., "test link" above) via the
+`{{title}}` variable. It will be set to "Untitled video" or "Untitled audio"
+if no title was set. You can access the fallback text ("Your browser does not
+support ...")  via the `{{fallback}}` variable. See below for how to
+customize/translate the text.
 
 ## Options reference
 
@@ -184,7 +201,7 @@ Default: `false`.
 
 #### embedPlaceDirectiveRegexp
 
-Regexp. Regular expression for the directive which is used to set the place for media embeds in case of non-inline embedding. 
+Regexp. Regular expression for the directive which is used to set the place for media embeds in case of non-inline embedding.
 
 Default: ```/^\[\[html5media\]\]/im```
 
@@ -234,6 +251,31 @@ Default: `true`.
 Boolean. Enables video/audio embed with ```[]()``` syntax.
 
 Default: `false`.
+
+#### messages
+
+Object. Override the built-in default fallback text. You can add translations as
+well, and load the translation by invoking `md.render` with a language
+environment variable, like so: `md.render('some text', { language: 'code' })`
+
+See `lib/index.js` for the default text in English.
+
+#### translateFn
+
+Object. Override the built-in translation function. The function has to process
+an object like this as its only argument, and return a string:
+
+````javascript
+{
+  messageKey: 'video not supported',
+  messageParam: 'somevideo.webm',
+  language: 'en'
+}
+````
+
+The keys you need to support are defined in `/lib.index.js`. You can access the
+default messages, or the messages you passed via `options.messages`, through
+the `this` keyword within your translation function.
 
 ## Credits
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,9 +6,33 @@
 var Mimoza = require('mimoza');
 var assign = require("lodash.assign");
 
+// Default UI messages. You can customize and add simple translations via
+// options.messages. The language has to be provided via the markdown-it
+// environment, e.g.:
+//
+// md.render('some text', { language: 'some code' })
+//
+// It will default to English if not provided. To use your own i18n framework,
+// you have to provide a translation function via options.translateFn.
+//
+// The "untitled video" / "untitled audio" messages are only relevant to usage
+// inside Handlebars templates, where you can access the title between [] as
+// {{title}}, and this text is used if no title is provided.
+var messages = {
+  en: {
+    'video not supported': 'Your browser does not support playing HTML5 video. ' +
+      'You can <a href="%s" download>download a copy of the video file</a> instead.',
+    'audio not supported': 'Your browser does not support playing HTML5 audio. ' +
+      'You can <a href="%s" download>download a copy of the audio file</a> instead.',
+    'content description': 'Here is a description of the content: %s',
+    'untitled video': 'Untitled video',
+    'untitled audio': 'Untitled audio'
+  }
+};
+
 function clearTokens(tokens, idx) {
-  for(var i = idx; i < tokens.length; i++) {
-    switch(tokens[i].type) {
+  for (var i = idx; i < tokens.length; i++) {
+    switch (tokens[i].type) {
       case 'link_close':
         tokens[i].hidden = true;
         break;
@@ -21,30 +45,51 @@ function clearTokens(tokens, idx) {
   }
 }
 
-function parseToken(tokens, idx) {
+function parseToken(tokens, idx, env) {
   var parsed = {};
   var token = tokens[idx];
+  var description = '';
 
   var aIndex = token.attrIndex('src');
   parsed.isLink = aIndex < 0;
-  if(parsed.isLink) {
+  if (parsed.isLink) {
     aIndex = token.attrIndex('href');
-    parsed.title = tokens[idx+1].content;
+    description = tokens[idx + 1].content;
   } else {
-    parsed.title = token.content;
+    description = token.content;
   }
 
   parsed.url = token.attrs[aIndex][1];
   parsed.mimeType = Mimoza.getMimeType(parsed.url);
   var RE = /^(audio|video)\/.*/gi;
   var mimetype_matches = RE.exec(parsed.mimeType);
-  if(mimetype_matches === null) {
+  if (mimetype_matches === null) {
     parsed.mediaType = null;
   } else {
     parsed.mediaType = mimetype_matches[1];
+  }
 
-    if(!parsed.title) {
-      parsed.title = "untitled " + parsed.mediaType;
+  if (parsed.mediaType !== null) {
+    // For use as titles in handlebars templates, we store the description
+    // in parsed.title. For use as fallback text, we store it in parsed.fallback
+    // alongside the standard fallback text.
+    parsed.fallback = translate({
+      messageKey: parsed.mediaType + ' not supported',
+      messageParam: parsed.url,
+      language: env.language
+    });
+    if (description.trim().length) {
+      parsed.fallback += '\n' + translate({
+        messageKey: 'content description',
+        messageParam: description,
+        language: env.language
+      });
+      parsed.title = description;
+    } else {
+      parsed.title = translate({
+        messageKey: 'untitled ' + parsed.mediaType,
+        language: env.language
+      });
     }
   }
   return parsed;
@@ -59,7 +104,7 @@ function renderMediaEmbed(parsed, options) {
   var attributes = options.attributes[parsed.mediaType];
   var useHandlebars = false;
 
-  if(options.templateName) {
+  if (options.templateName) {
     if (typeof HandlebarsTemplates === "undefined") {
       console.log("handlebars_assets is not on the assets pipeline; fall back to the usual mode");
     } else {
@@ -67,33 +112,34 @@ function renderMediaEmbed(parsed, options) {
     }
   }
 
-  if(useHandlebars) {
+  if (useHandlebars) {
     return HandlebarsTemplates[options.templateName]({
       media_type: parsed.mediaType,
       attributes: attributes,
       mimetype: parsed.mimeType,
       source_url: parsed.url,
       title: parsed.title,
-      needs_cover: parsed.mediaType==="video"
+      fallback: parsed.fallback,
+      needs_cover: parsed.mediaType === "video"
     });
   } else {
     return ['<' + parsed.mediaType + ' ' + attributes + '>',
       '<source type="' + parsed.mimeType + '" src="' + parsed.url + '"></source>',
-      parsed.title,
+      parsed.fallback,
       '</' + parsed.mediaType + '>'
     ].join('\n');
   }
 }
 
 function html5EmbedRenderer(tokens, idx, options, env, renderer, defaultRender) {
-  var parsed = parseToken(tokens, idx);
+  var parsed = parseToken(tokens, idx, env);
 
-  if(!isAllowedMimeType(parsed, options.html5embed)) {
+  if (!isAllowedMimeType(parsed, options.html5embed)) {
     return defaultRender(tokens, idx, options, env, renderer);
   }
 
-  if(parsed.isLink) {
-    clearTokens(tokens, idx+1);
+  if (parsed.isLink) {
+    clearTokens(tokens, idx + 1);
   }
 
   return renderMediaEmbed(parsed, options.html5embed);
@@ -101,9 +147,9 @@ function html5EmbedRenderer(tokens, idx, options, env, renderer, defaultRender) 
 
 function forEachLinkOpen(state, action) {
   state.tokens.forEach(function(token, _idx, _tokens) {
-    if(token.type === "inline") {
+    if (token.type === "inline") {
       token.children.forEach(function(token, idx, tokens) {
-        if(token.type === "link_open") {
+        if (token.type === "link_open") {
           action(tokens, idx);
         }
       });
@@ -130,10 +176,42 @@ function findDirective(state, startLine, _endLine, silent, regexp, build_token) 
 
   // Build content
   var token = build_token();
-  token.map = [ startLine, state.line];
+  token.map = [startLine, state.line];
   token.markup = currentLine;
 
   return true;
+}
+
+/**
+ * Very basic translation function. To translate or customize the UI messages,
+ * set options.messages. To also customize the translation function itself, set
+ * option.translateFn to a function that handles the same message object format.
+ *
+ * @param {Object} messageObj
+ *  the message object
+ * @param {String} messageObj.messageKey
+ *  an identifier used for looking up the message in i18n files
+ * @param {String} messageObj.messageParam
+ *  for substitution of %s for filename and description in the respective
+ *  messages
+ * @param {String} [messageObj.language='en']
+ *  a language code, ignored in the default implementation
+ * @this {Object}
+ *  the built-in default messages, or options.messages if set
+ */
+function translate(messageObj) {
+  // Default to English if we don't have this message, or don't support this
+  // language at all
+  var language = messageObj.language && this[messageObj.language] &&
+    this[messageObj.language][messageObj.messageKey] ?
+    messageObj.language :
+    'en';
+  var rv = this[language][messageObj.messageKey];
+
+  if (messageObj.messageParam) {
+    rv = rv.replace('%s', messageObj.messageParam);
+  }
+  return rv;
 }
 
 module.exports = function html5_embed_plugin(md, options) {
@@ -146,29 +224,30 @@ module.exports = function html5_embed_plugin(md, options) {
     useImageSyntax: true,
     inline: true,
     autoAppend: false,
-    embedPlaceDirectiveRegexp: /^\[\[html5media\]\]/im
+    embedPlaceDirectiveRegexp: /^\[\[html5media\]\]/im,
+    messages: messages
   };
   var options = assign({}, defaults, options.html5embed);
 
-  if(!options.inline) {
+  if (!options.inline) {
     md.block.ruler.before("paragraph", "html5embed", function(state, startLine, endLine, silent) {
       return findDirective(state, startLine, endLine, silent, options.embedPlaceDirectiveRegexp, function() {
         return state.push("html5media", "html5media", 0);
       });
     });
 
-    md.renderer.rules.html5media = function(tokens, index) {
+    md.renderer.rules.html5media = function(tokens, index, _, env) {
       var result = "";
       forEachLinkOpen(gstate, function(tokens, idx) {
-        var parsed = parseToken(tokens, idx);
+        var parsed = parseToken(tokens, idx, env);
 
-        if(!isAllowedMimeType(parsed, options)) {
+        if (!isAllowedMimeType(parsed, options)) {
           return;
         }
 
         result += renderMediaEmbed(parsed, options);
       });
-      if(result.length) {
+      if (result.length) {
         result += "\n";
       }
       return result;
@@ -178,18 +257,18 @@ module.exports = function html5_embed_plugin(md, options) {
     md.core.ruler.push("grab_state", function(state) {
       gstate = state;
 
-      if(options.autoAppend) {
+      if (options.autoAppend) {
         var token = new state.Token("html5media", "", 0);
         state.tokens.push(token);
       }
     });
   }
 
-  if(typeof options.isAllowedMimeType === "undefined") {
+  if (typeof options.isAllowedMimeType === "undefined") {
     options.isAllowedMimeType = options.is_allowed_mime_type;
   }
 
-  if(options.inline && options.useImageSyntax) {
+  if (options.inline && options.useImageSyntax) {
     var defaultRender = md.renderer.rules.image;
     md.renderer.rules.image = function(tokens, idx, opt, env, self) {
       opt.html5embed = options;
@@ -197,7 +276,7 @@ module.exports = function html5_embed_plugin(md, options) {
     }
   }
 
-  if(options.inline && options.useLinkSyntax) {
+  if (options.inline && options.useLinkSyntax) {
     var defaultRender = md.renderer.rules.link_open || function(tokens, idx, options, env, self) {
       return self.renderToken(tokens, idx, options);
     };
@@ -206,4 +285,10 @@ module.exports = function html5_embed_plugin(md, options) {
       return html5EmbedRenderer(tokens, idx, opt, env, self, defaultRender);
     };
   }
+
+  // options.messages will be set to built-in messages at the beginning of this
+  // file if not configured
+  translate = typeof options.translateFn == 'function' ?
+    options.translateFn.bind(options.messages) :
+    translate.bind(options.messages);
 };

--- a/test/fixtures/image-syntax-custom-messages.txt
+++ b/test/fixtures/image-syntax-custom-messages.txt
@@ -1,0 +1,37 @@
+Video with image syntax:
+.
+![](https://example.com/file.webm)
+.
+<p><video width="320" height="240" class="audioplayer" controls>
+<source type="video/webm" src="https://example.com/file.webm"></source>
+You cannot play this but you can download it: https://example.com/file.webm
+</video></p>
+.
+
+Audio with image syntax:
+.
+![](https://example.com/file.ogg)
+.
+<p><audio width="320" controls class="audioplayer">
+<source type="audio/ogg" src="https://example.com/file.ogg"></source>
+You cannot play this either but you can download it: https://example.com/file.ogg
+</audio></p>
+.
+
+Check usual image is not broken:
+.
+![](https://example.com/file.png)
+.
+<p><img src="https://example.com/file.png" alt=""></p>
+.
+
+Video with image syntax and title:
+.
+![some fancy title](https://example.com/file.webm)
+.
+<p><video width="320" height="240" class="audioplayer" controls>
+<source type="video/webm" src="https://example.com/file.webm"></source>
+You cannot play this but you can download it: https://example.com/file.webm
+It may contain this: some fancy title
+</video></p>
+.

--- a/test/fixtures/image-syntax-with-translation.txt
+++ b/test/fixtures/image-syntax-with-translation.txt
@@ -1,0 +1,37 @@
+Video with image syntax:
+.
+![](https://example.com/file.webm)
+.
+<p><video width="320" height="240" class="audioplayer" controls>
+<source type="video/webm" src="https://example.com/file.webm"></source>
+DU KANNST DIES NICHT ABSPIELEN ABER HERUNTERLADEN: https://example.com/file.webm
+</video></p>
+.
+
+Audio with image syntax:
+.
+![](https://example.com/file.ogg)
+.
+<p><audio width="320" controls class="audioplayer">
+<source type="audio/ogg" src="https://example.com/file.ogg"></source>
+DU KANNST DIES AUCH NICHT ABSPIELEN ABER HERUNTERLADEN: https://example.com/file.ogg
+</audio></p>
+.
+
+Check usual image is not broken:
+.
+![](https://example.com/file.png)
+.
+<p><img src="https://example.com/file.png" alt=""></p>
+.
+
+Video with image syntax and title:
+.
+![some fancy title](https://example.com/file.webm)
+.
+<p><video width="320" height="240" class="audioplayer" controls>
+<source type="video/webm" src="https://example.com/file.webm"></source>
+DU KANNST DIES NICHT ABSPIELEN ABER HERUNTERLADEN: https://example.com/file.webm
+DIES KÖNNTE ENTHALTEN SEIN: some fancy title
+</video></p>
+.

--- a/test/fixtures/image-syntax.txt
+++ b/test/fixtures/image-syntax.txt
@@ -4,7 +4,7 @@ Video with image syntax:
 .
 <p><video width="320" height="240" class="audioplayer" controls>
 <source type="video/webm" src="https://example.com/file.webm"></source>
-untitled video
+Your browser does not support playing HTML5 video. You can <a href="https://example.com/file.webm" download>download a copy of the video file</a> instead.
 </video></p>
 .
 
@@ -14,7 +14,7 @@ Audio with image syntax:
 .
 <p><audio width="320" controls class="audioplayer">
 <source type="audio/ogg" src="https://example.com/file.ogg"></source>
-untitled audio
+Your browser does not support playing HTML5 audio. You can <a href="https://example.com/file.ogg" download>download a copy of the audio file</a> instead.
 </audio></p>
 .
 
@@ -31,7 +31,7 @@ Video with image syntax and title:
 .
 <p><video width="320" height="240" class="audioplayer" controls>
 <source type="video/webm" src="https://example.com/file.webm"></source>
-some fancy title
+Your browser does not support playing HTML5 video. You can <a href="https://example.com/file.webm" download>download a copy of the video file</a> instead.
+Here is a description of the content: some fancy title
 </video></p>
 .
-

--- a/test/fixtures/link-syntax.txt
+++ b/test/fixtures/link-syntax.txt
@@ -4,7 +4,8 @@ Video with link syntax:
 .
 <p><video controls preload="metadata">
 <source type="video/webm" src="https://example.com/file.webm"></source>
-test link
+Your browser does not support playing HTML5 video. You can <a href="https://example.com/file.webm" download>download a copy of the video file</a> instead.
+Here is a description of the content: test link
 </video></p>
 .
 
@@ -14,7 +15,7 @@ Video with link syntax (no text label):
 .
 <p><video controls preload="metadata">
 <source type="video/webm" src="https://example.com/file.webm"></source>
-untitled video
+Your browser does not support playing HTML5 video. You can <a href="https://example.com/file.webm" download>download a copy of the video file</a> instead.
 </video></p>
 .
 
@@ -24,5 +25,3 @@ Check usual link is not broken:
 .
 <p><a href="https://example.com/file.php">test link</a></p>
 .
-
-

--- a/test/fixtures/mime-filter.txt
+++ b/test/fixtures/mime-filter.txt
@@ -11,7 +11,7 @@ MP3 is allowed
 .
 <p><audio controls preload="metadata">
 <source type="audio/mpeg" src="https://example.com/file.mp3"></source>
-untitled audio
+Your browser does not support playing HTML5 audio. You can <a href="https://example.com/file.mp3" download>download a copy of the audio file</a> instead.
 </audio></p>
 .
 
@@ -21,7 +21,8 @@ OGV is allowed
 .
 <p><video controls preload="metadata">
 <source type="video/ogg" src="https://example.com/file.ogv"></source>
-test link
+Your browser does not support playing HTML5 video. You can <a href="https://example.com/file.ogv" download>download a copy of the video file</a> instead.
+Here is a description of the content: test link
 </video></p>
 .
 
@@ -31,4 +32,3 @@ Non-media link
 .
 <p><a href="https://example.com/file.php">test link</a></p>
 .
-

--- a/test/fixtures/with-auto-append.txt
+++ b/test/fixtures/with-auto-append.txt
@@ -5,6 +5,7 @@
 <p><a href="https://example.com/file.webm">test link</a></p>
 <video controls preload="metadata">
 <source type="video/webm" src="https://example.com/file.webm"></source>
-test link
+Your browser does not support playing HTML5 video. You can <a href="https://example.com/file.webm" download>download a copy of the video file</a> instead.
+Here is a description of the content: test link
 </video>
 .

--- a/test/fixtures/with-handlebars.txt
+++ b/test/fixtures/with-handlebars.txt
@@ -9,7 +9,7 @@ MP3:
 .
 [](https://example.com/file.mp3)
 .
-<p><h1>untitled audio</h1><div class="body"><audio ><source type="audio/mpeg" src="https://example.com/file.mp3"/></audio></div></p>
+<p><h1>Untitled audio</h1><div class="body"><audio ><source type="audio/mpeg" src="https://example.com/file.mp3"/></audio></div></p>
 .
 
 OGV:
@@ -25,4 +25,3 @@ Non-media link
 .
 <p><a href="https://example.com/file.php">test link</a></p>
 .
-

--- a/test/fixtures/with-placeholder-syntax.txt
+++ b/test/fixtures/with-placeholder-syntax.txt
@@ -7,7 +7,8 @@
 <p><a href="https://example.com/file.webm">test link</a></p>
 <video controls preload="metadata">
 <source type="video/webm" src="https://example.com/file.webm"></source>
-test link
+Your browser does not support playing HTML5 video. You can <a href="https://example.com/file.webm" download>download a copy of the video file</a> instead.
+Here is a description of the content: test link
 </video>
 .
 

--- a/test/test.js
+++ b/test/test.js
@@ -152,9 +152,9 @@ describe('markdown-it-html5-embed with image syntax + custom translation fn', fu
   var env = { language: 'de' };
 
   // Pass along env to generated tests
-  md.orig_render = md.render;
+  md.origRender = md.render;
   md.render = function(input) {
-    return this.orig_render(input, env);
+    return this.origRender(input, env);
   };
 
   generate(path.join(__dirname, 'fixtures/image-syntax-with-translation.txt'), md);

--- a/test/test.js
+++ b/test/test.js
@@ -3,54 +3,76 @@
 var path = require('path');
 var generate = require('markdown-it-testgen');
 
+// For testing custom messages and translations
+var customMessages = {
+  en: {
+    'video not supported': 'You cannot play this but you can download it: %s',
+    'audio not supported': 'You cannot play this either but you can download it: %s',
+    'content description': 'It may contain this: %s'
+  },
+  de: {
+    'video not supported': 'Du kannst dies nicht abspielen aber herunterladen: %s',
+    'audio not supported': 'Du kannst dies auch nicht abspielen aber herunterladen: %s',
+    'content description': 'Dies könnte enthalten sein: %s'
+  }
+};
+
 describe('markdown-it-html5-embed with image syntax', function() {
-  var option = { html5embed: {
-    useImageSyntax: true,
-    attributes: {
-      'audio': 'width="320" controls class="audioplayer"',
-      'video': 'width="320" height="240" class="audioplayer" controls'
+  var option = {
+    html5embed: {
+      useImageSyntax: true,
+      attributes: {
+        'audio': 'width="320" controls class="audioplayer"',
+        'video': 'width="320" height="240" class="audioplayer" controls'
+      }
     }
-  } };
-  
+  };
+
   var md = require('markdown-it')().use(require('../lib'), option);
   generate(path.join(__dirname, 'fixtures/image-syntax.txt'), md);
 });
 
 describe('markdown-it-html5-embed with link syntax', function() {
-  var option = { html5embed: {
-    useLinkSyntax: true
-  } };
-  
+  var option = {
+    html5embed: {
+      useLinkSyntax: true
+    }
+  };
+
   var md = require('markdown-it')().use(require('../lib'), option);
   generate(path.join(__dirname, 'fixtures/link-syntax.txt'), md);
 });
 
 describe('markdown-it-html5-embed mime type filtering', function() {
-  var option = { html5embed: {
-    useLinkSyntax: true,
-    isAllowedMimeType: function(mimetype) {
-      return (mimetype[0] == 'audio/mpeg') || (mimetype[0] == 'video/ogg');
+  var option = {
+    html5embed: {
+      useLinkSyntax: true,
+      isAllowedMimeType: function(mimetype) {
+        return (mimetype[0] == 'audio/mpeg') || (mimetype[0] == 'video/ogg');
+      }
     }
-  } };
+  };
 
   var md = require('markdown-it')().use(require('../lib'), option);
   generate(path.join(__dirname, 'fixtures/mime-filter.txt'), md);
 });
 
 describe('markdown-it-html5-embed with handlebars', function() {
-  before(function (){
+  before(function() {
     var Handlebars = require("handlebars");
-    global.HandlebarsTemplates = {"template": Handlebars.compile(  "<h1>{{title}}</h1><div class=\"body\"><{{media_type}} {{attributes}}><source type=\"{{mimetype}}\" src=\"{{source_url}}\"/></{{media_type}}></div>")};
+    global.HandlebarsTemplates = { "template": Handlebars.compile("<h1>{{title}}</h1><div class=\"body\"><{{media_type}} {{attributes}}><source type=\"{{mimetype}}\" src=\"{{source_url}}\"/></{{media_type}}></div>") };
   });
 
-  var option = { html5embed: {
-    useLinkSyntax: true,
-    templateName: "template",
-    attributes: {
-      "video": "",
-      "audio": ""
+  var option = {
+    html5embed: {
+      useLinkSyntax: true,
+      templateName: "template",
+      attributes: {
+        "video": "",
+        "audio": ""
+      }
     }
-  } };
+  };
 
   var md = require('markdown-it')().use(require('../lib'), option);
 
@@ -58,9 +80,11 @@ describe('markdown-it-html5-embed with handlebars', function() {
 });
 
 describe("embedding with [[html5embed]] clause", function() {
-  var options = { html5embed: {
+  var options = {
+    html5embed: {
       inline: false
-  } };
+    }
+  };
 
   var md = require('markdown-it')().use(require('../lib'), options);
 
@@ -68,12 +92,70 @@ describe("embedding with [[html5embed]] clause", function() {
 });
 
 describe("embedding with auto-append", function() {
-  var options = { html5embed: {
-    inline: false,
-    autoAppend: true
-  } };
+  var options = {
+    html5embed: {
+      inline: false,
+      autoAppend: true
+    }
+  };
 
   var md = require('markdown-it')().use(require('../lib'), options);
 
   generate(path.join(__dirname, 'fixtures/with-auto-append.txt'), md);
+});
+
+describe('markdown-it-html5-embed with image syntax + custom messages', function() {
+  var option = {
+    html5embed: {
+      useImageSyntax: true,
+      attributes: {
+        'audio': 'width="320" controls class="audioplayer"',
+        'video': 'width="320" height="240" class="audioplayer" controls'
+      },
+      messages: customMessages
+    }
+  };
+  // Don't re-use cached function with old bindings
+  delete require.cache[require.resolve('../lib')];
+
+  var md = require('markdown-it')().use(require('../lib'), option);
+  generate(path.join(__dirname, 'fixtures/image-syntax-custom-messages.txt'), md);
+});
+
+describe('markdown-it-html5-embed with image syntax + custom translation fn', function() {
+
+  // Simply get the upper case version of the translation, if any
+  var translateFn = function(messageObj) {
+    return this[messageObj.language][messageObj.messageKey] ?
+      this[messageObj.language][messageObj.messageKey]
+      .toUpperCase()
+      .replace('%S', messageObj.messageParam) :
+      '';
+  };
+
+  var option = {
+    html5embed: {
+      useImageSyntax: true,
+      attributes: {
+        'audio': 'width="320" controls class="audioplayer"',
+        'video': 'width="320" height="240" class="audioplayer" controls'
+      },
+      messages: customMessages,
+      translateFn: translateFn
+    }
+  };
+
+  // Don't re-use cached function with old bindings
+  delete require.cache[require.resolve('../lib')];
+
+  var md = require('markdown-it')().use(require('../lib'), option);
+  var env = { language: 'de' };
+
+  // Pass along env to generated tests
+  md.orig_render = md.render;
+  md.render = function(input) {
+    return this.orig_render(input, env);
+  };
+
+  generate(path.join(__dirname, 'fixtures/image-syntax-with-translation.txt'), md);
 });


### PR DESCRIPTION
Instead of hardcoding strings that cannot be overridden by the
user, we're using Markdown-It's environment object to support
translation, either with a built-in very naive function, or
with a user-provided function. The English messages can also
be customized without touching the translation logic.

The transparent content inside `<video>` and `<audio>` tags is not
a standard accessibility feature like the ALT text; it is only
shown when the browser cannot play this content at all. The
standard recommendation is to use this text to offer a download
link. See, e.g., the examples in
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video

This implementation does so, but it also adds the descriptive
text (if any) for good measure. For backwards compatibility, we
continue to store the descriptive text (or "Untitled ...")
in parsed.title, and it can still be accessed inside the
Handlebars template via {{title}}.